### PR TITLE
add user impersonation, and user and org metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@propelauth/node",
-  "version": "v2.0.1",
+  "version": "v2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@propelauth/node",
-      "version": "v2.0.1",
+      "version": "v2.1",
       "license": "MIT",
       "dependencies": {
         "jsonwebtoken": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/PropelAuth/node"
   },
-  "version": "v2.0.7",
+  "version": "v2.1",
   "license": "MIT",
   "keywords": [
     "auth",

--- a/src/api.ts
+++ b/src/api.ts
@@ -289,6 +289,7 @@ export type UpdateUserMetadataRequest = {
     firstName?: string,
     lastName?: string,
     pictureUrl?: string
+    metadata?: {[key: string]: any}
 }
 
 export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
@@ -301,6 +302,7 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         first_name: updateUserMetadataRequest.firstName,
         last_name: updateUserMetadataRequest.lastName,
         picture_url: updateUserMetadataRequest.pictureUrl,
+        metadata: updateUserMetadataRequest.metadata,
     }
     return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
@@ -678,6 +680,7 @@ export type UpdateOrgRequest = {
     orgId: string
     name?: string
     canSetupSaml?: boolean
+    metadata?: {[key: string]: any}
 }
 
 export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
@@ -688,6 +691,7 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
     const request = {
         name: updateOrgRequest.name,
         can_setup_saml: updateOrgRequest.canSetupSaml,
+        metadata: updateOrgRequest.metadata,
     }
     return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
@@ -800,6 +804,10 @@ function parseUser(response: string) {
             this.legacyUserId = value
         } else if (key === "org_id_to_org_info") {
             this.orgIdToOrgInfo = value;
+        } else if (key === "impersonated_user_id") {
+            this.impersonatorUserId = value;
+        } else if (key === "metadata") {
+            this.metadata = value;
         } else {
             return value
         }

--- a/src/user.ts
+++ b/src/user.ts
@@ -5,7 +5,10 @@ export type User = {
     // If you used our migration APIs to migrate this user from a different system,
     //   this is their original ID from that system.
     legacyUserId?: string
+    impersonatorUserId?: string
+    metadata?: {[key: string]: any}
 }
+
 export type Org = {
     orgId: string,
     name: string,
@@ -34,20 +37,24 @@ export type UserMetadata = {
     // If you used our migration APIs to migrate this user from a different system,
     //   this is their original ID from that system.
     legacyUserId?: string
+    impersonatorUserId?: string
+    metadata?: {[key: string]: any}
 }
 
 export class OrgMemberInfo {
     public readonly orgId: string
     public readonly orgName: string
+    public readonly orgMetadata: {[key: string]: any}
     public readonly urlSafeOrgName: string
 
     private readonly userAssignedRole: string
     private readonly userInheritedRolesPlusCurrentRole: string[]
     private readonly userPermissions: string[]
 
-    constructor(orgId: string, orgName: string, urlSafeOrgName: string, userAssignedRole: string, userInheritedRolesPlusCurrentRole: string[], userPermissions: string[]) {
+    constructor(orgId: string, orgName: string, orgMetadata: {[key: string]: any}, urlSafeOrgName: string, userAssignedRole: string, userInheritedRolesPlusCurrentRole: string[], userPermissions: string[]) {
         this.orgId = orgId
         this.orgName = orgName
+        this.orgMetadata = orgMetadata
         this.urlSafeOrgName = urlSafeOrgName
 
         this.userAssignedRole = userAssignedRole
@@ -101,17 +108,21 @@ export type OrgIdToOrgMemberInfo = {
 export type InternalOrgMemberInfo = {
     org_id: string
     org_name: string
+    org_metadata: {[key: string]: any}
     url_safe_org_name: string
     user_role: string
     inherited_user_roles_plus_current_role: string[]
     user_permissions: string[]
 }
+
 export type InternalUser = {
     user_id: string
     org_id_to_org_member_info?: { [org_id: string]: InternalOrgMemberInfo }
 
     // If you used our migration APIs to migrate this user from a different system, this is their original ID from that system.
     legacy_user_id?: string
+    impersonator_user_id?: string
+    metadata?: {[key: string]: any}
 }
 
 export function toUser(snake_case: InternalUser): User {
@@ -119,6 +130,8 @@ export function toUser(snake_case: InternalUser): User {
         userId: snake_case.user_id,
         orgIdToOrgMemberInfo: toOrgIdToOrgMemberInfo(snake_case.org_id_to_org_member_info),
         legacyUserId: snake_case.legacy_user_id,
+        impersonatorUserId: snake_case.impersonator_user_id,
+        metadata: snake_case.metadata,
     }
 }
 
@@ -136,6 +149,7 @@ export function toOrgIdToOrgMemberInfo(snake_case?: {
             camelCase[key] = new OrgMemberInfo(
                 snakeCaseValue.org_id,
                 snakeCaseValue.org_name,
+                snakeCaseValue.org_metadata,
                 snakeCaseValue.url_safe_org_name,
                 snakeCaseValue.user_role,
                 snakeCaseValue.inherited_user_roles_plus_current_role,

--- a/test/middleware.ts
+++ b/test/middleware.ts
@@ -7,7 +7,7 @@ import {initBaseAuth} from "../src"
 import {TokenVerificationMetadata} from "../src/api";
 import {RequiredOrgInfo} from "../src/auth"
 import {ForbiddenException, UnauthorizedException, UnexpectedException} from "../src/exceptions";
-import {InternalOrgMemberInfo, OrgMemberInfo, InternalUser, toUser, User} from "../src/user"
+import {InternalOrgMemberInfo, InternalUser, OrgMemberInfo, toUser, User} from "../src/user"
 
 const AUTH_URL = "https://auth.example.com"
 const ALGO = "RS256"
@@ -142,6 +142,7 @@ test("toUser converts correctly with orgs", async () => {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": {
                 org_id: "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
                 org_name: "orgA",
+                org_metadata: {"orgdata_a": "orgvalue_a"},
                 url_safe_org_name: "orga",
                 user_role: "Owner",
                 inherited_user_roles_plus_current_role: ["Owner", "Admin", "Member"],
@@ -150,6 +151,7 @@ test("toUser converts correctly with orgs", async () => {
             "4ca20d17-5021-4d62-8b3d-148214fa8d6d": {
                 org_id: "4ca20d17-5021-4d62-8b3d-148214fa8d6d",
                 org_name: "orgB",
+                org_metadata: {"orgdata_b": "orgvalue_b"},
                 url_safe_org_name: "orgb",
                 user_role: "Admin",
                 inherited_user_roles_plus_current_role: ["Admin", "Member"],
@@ -158,6 +160,7 @@ test("toUser converts correctly with orgs", async () => {
             "15a31d0c-d284-4e7b-80a2-afb23f939cc3": {
                 org_id: "15a31d0c-d284-4e7b-80a2-afb23f939cc3",
                 org_name: "orgC",
+                org_metadata: {"orgdata_c": "orgvalue_c"},
                 url_safe_org_name: "orgc",
                 user_role: "Member",
                 inherited_user_roles_plus_current_role: ["Member"],
@@ -172,6 +175,7 @@ test("toUser converts correctly with orgs", async () => {
             "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a": new OrgMemberInfo(
                 "99ee1329-e536-4aeb-8e2b-9f56c1b8fe8a",
                 "orgA",
+                {"orgdata_a": "orgvalue_a"},
                 "orga",
                 "Owner",
                 ["Owner", "Admin", "Member"],
@@ -180,6 +184,7 @@ test("toUser converts correctly with orgs", async () => {
             "4ca20d17-5021-4d62-8b3d-148214fa8d6d": new OrgMemberInfo(
                 "4ca20d17-5021-4d62-8b3d-148214fa8d6d",
                 "orgB",
+                {"orgdata_b": "orgvalue_b"},
                 "orgb",
                 "Admin",
                 ["Admin", "Member"],
@@ -188,6 +193,7 @@ test("toUser converts correctly with orgs", async () => {
             "15a31d0c-d284-4e7b-80a2-afb23f939cc3": new OrgMemberInfo(
                 "15a31d0c-d284-4e7b-80a2-afb23f939cc3",
                 "orgC",
+                {"orgdata_c": "orgvalue_c"},
                 "orgc",
                 "Member",
                 ["Member"],
@@ -221,6 +227,9 @@ test("validateAccessTokenAndGetUserWithOrgInfoWithMinimumRole get user and org f
         org_id_to_org_member_info: {
             [orgMemberInfo.org_id]: orgMemberInfo,
         },
+        metadata: {
+            "userdata": "uservalue",
+        }
     }
     const orgInfo: RequiredOrgInfo = {
         orgId: orgMemberInfo.org_id,
@@ -264,7 +273,7 @@ test("validateAccessTokenAndGetUserWithOrgInfoWithMinimumRole fails for invalid 
         orgId: uuid(),
         orgName: "orgName",
     }
-    
+
     await expect(validateAccessTokenAndGetUserWithOrgInfo(undefined, orgInfo))
         .rejects
         .toThrow(UnauthorizedException)
@@ -508,6 +517,7 @@ function randomOrg(): InternalOrgMemberInfo {
     return {
         org_id: uuid(),
         org_name: randomString(),
+        org_metadata: {"internalData": randomString()},
         url_safe_org_name: urlSafeOrgName,
         user_role: "Admin",
         inherited_user_roles_plus_current_role: ["Admin", "Member"],


### PR DESCRIPTION
The User now has an "impersonator_user_id" field. This is the UUID of the other user that is impersonating this user. It will be None if impersonation is not happening (which it normally isn't).

The User objects also have a "metadata" field, which is private, user-specific metadata which can be set via the regular update_metadata endpoint. The user will never see or use this metadata, it's just for the PropelAuth customer.

The Org objects have an "org_metadata" field. Much like user metadata, this is a private field.

The metadata objects are simple hashes with a string key and any JSON object for the value.