### PR TITLE
new endpoints - api keys and org control

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -969,7 +969,7 @@ export function deleteEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey:
         })
 }
 
-export function validateEndUserApiKeys(authUrl: URL, apiKey: string, endUserApiKey: string): Promise<EndUserApiKeyValidation> {
+export function validateEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey: string): Promise<EndUserApiKeyValidation> {
     const request = {
         api_key_token: endUserApiKey,
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -828,19 +828,19 @@ export function disallowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey
 
 // functions for managing end user api keys
 
-export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<ApiKeyFull> {
-    if (!isValidHex(apiKey)) {
+export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyFull> {
+    if (!isValidHex(apiKeyId)) {
         throw new ApiKeyFetchException("Invalid api key")
     }
 
-    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
+                throw new Error("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -865,14 +865,14 @@ export function fetchCurrentApiKeys(authUrl: URL, integrationApiKey: string, api
     }
     const queryString = formatQueryParameters(request)
 
-    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
+                throw new Error("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -889,14 +889,14 @@ export function fetchArchivedApiKeys(authUrl: URL, integrationApiKey: string, ap
     }
     const queryString = formatQueryParameters(request)
 
-    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
+                throw new Error("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -908,7 +908,7 @@ export type ApiKeysCreateRequest = {
     orgId?: string
     userId?: string
     expiresAtSeconds?: number
-    metadata?: string
+    metadata?: object
 }
 export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
     const request = {
@@ -925,7 +925,7 @@ export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCrea
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyCreateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyCreateException("Unknown error when creating the end user api key")
+                throw new Error("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -936,8 +936,8 @@ export type ApiKeyUpdateRequest = {
     expiresAtSeconds?: number
     metadata?: string
 }
-export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKey: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
-    if (!isValidHex(apiKey)) {
+export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+    if (!isValidHex(apiKeyId)) {
         throw new ApiKeyUpdateException("Invalid api key")
     }
 
@@ -946,26 +946,26 @@ export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKey: st
         metadata: apiKeyUpdate.metadata,
     }
 
-    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "PATCH", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "PATCH", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyUpdateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyUpdateException("Unknown error when updating the end user api key")
+                throw new Error("Unknown error when updating the end user api key")
             }
 
             return true
         })
 }
 
-export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<boolean> {
-    if (!isValidHex(apiKey)) {
+export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<boolean> {
+    if (!isValidHex(apiKeyId)) {
         throw new ApiKeyDeleteException("Invalid api key")
     }
 
-    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "DELETE")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKeyId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
                 throw new Error("integrationApiKey is incorrect")
@@ -974,20 +974,20 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKey: st
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyDeleteException("Unknown error when deleting the end user api key")
+                throw new Error("Unknown error when deleting the end user api key")
             }
 
             return true
         })
 }
 
-export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<ApiKeyValidation> {
-    if (!isValidHex(apiKey)) {
+export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyValidation> {
+    if (!isValidHex(apiKeyId)) {
         throw new ApiKeyValidateException("Invalid api key")
     }
 
     const request = {
-        api_key_token: apiKey,
+        api_key_token: apiKeyId,
     }
 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
@@ -997,7 +997,7 @@ export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKey: 
             } else if (httpResponse.statusCode === 400) {
                 throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new ApiKeyValidateException("Unknown error when updating the end user api key")
+                throw new Error("Unknown error when updating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -1005,7 +1005,7 @@ export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKey: 
 }
 
 const idRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
-const hexRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+const hexRegex = /^[0-9a-fA-F]{32}$/i;
 
 function isValidId(id: string): boolean {
     return idRegex.test(id)

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,9 +1,9 @@
 import {httpRequest} from "./http"
 import {
-    EndUserApiKeyFull,
-    EndUserApiKeyNew,
-    EndUserApiKeyResultPage,
-    EndUserApiKeyValidation,
+    ApiKeyFull,
+    ApiKeyNew,
+    ApiKeyResultPage,
+    ApiKeyValidation,
     Org,
     User,
     UserMetadata
@@ -22,11 +22,11 @@ import {
     UpdateOrgException,
     AccessTokenCreationException,
     UserNotFoundException,
-    EndUserApiKeyFetchException,
-    EndUserApiKeyCreateException,
-    EndUserApiKeyUpdateException,
-    EndUserApiKeyDeleteException,
-    EndUserApiKeyValidateException
+    ApiKeyFetchException,
+    ApiKeyCreateException,
+    ApiKeyUpdateException,
+    ApiKeyDeleteException,
+    ApiKeyValidateException
 } from "./exceptions";
 
 export type TokenVerificationMetadata = {
@@ -35,15 +35,15 @@ export type TokenVerificationMetadata = {
 }
 
 export function fetchTokenVerificationMetadata(authUrl: URL,
-                                               apiKey: string,
+                                               integrationApiKey: string,
                                                manualTokenVerificationMetadata?: TokenVerificationMetadata): Promise<TokenVerificationMetadata> {
     if (manualTokenVerificationMetadata) {
         return Promise.resolve(manualTokenVerificationMetadata)
     }
 
-    return httpRequest(authUrl, apiKey, "/api/v1/token_verification_metadata", "GET").then((httpResponse) => {
+    return httpRequest(authUrl, integrationApiKey, "/api/v1/token_verification_metadata", "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
-            throw new Error("apiKey is incorrect")
+            throw new Error("integrationApiKey is incorrect")
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
             throw new Error("Unknown error when fetching token verification metadata")
         }
@@ -56,19 +56,19 @@ export function fetchTokenVerificationMetadata(authUrl: URL,
     })
 }
 
-export function fetchUserMetadataByUserIdWithIdCheck(authUrl: URL, apiKey: string, userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
+export function fetchUserMetadataByUserIdWithIdCheck(authUrl: URL, integrationApiKey: string, userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
     if (isValidId(userId)) {
-        return fetchUserMetadataByQuery(authUrl, apiKey, userId, {include_orgs: includeOrgs || false})
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, userId, {include_orgs: includeOrgs || false})
     } else {
         return Promise.resolve(null);
     }
 }
 
-export function fetchUserMetadataByQuery(authUrl: URL, apiKey: string, pathParam: string, query: any): Promise<UserMetadata | null> {
+export function fetchUserMetadataByQuery(authUrl: URL, integrationApiKey: string, pathParam: string, query: any): Promise<UserMetadata | null> {
     const queryString = formatQueryParameters(query)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${pathParam}?${queryString}`, "GET").then((httpResponse) => {
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${pathParam}?${queryString}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
-            throw new Error("apiKey is incorrect")
+            throw new Error("integrationApiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
             return null
         } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -81,7 +81,7 @@ export function fetchUserMetadataByQuery(authUrl: URL, apiKey: string, pathParam
 
 export function fetchBatchUserMetadata(
     authUrl: URL,
-    apiKey: string,
+    integrationApiKey: string,
     type: string,
     values: string[],
     keyFunction: (x: UserMetadata) => string,
@@ -89,10 +89,10 @@ export function fetchBatchUserMetadata(
 ): Promise<{ [key: string]: UserMetadata }> {
     const queryString = includeOrgs ? formatQueryParameters({include_orgs: includeOrgs}) : ""
     const jsonBody = {[type]: values}
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${type}?${queryString}`, "POST", JSON.stringify(jsonBody)).then(
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${type}?${queryString}`, "POST", JSON.stringify(jsonBody)).then(
         (httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Bad request " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -110,14 +110,14 @@ export function fetchBatchUserMetadata(
     )
 }
 
-export function fetchOrg(authUrl: URL, apiKey: string, orgId: string): Promise<Org | null> {
+export function fetchOrg(authUrl: URL, integrationApiKey: string, orgId: string): Promise<Org | null> {
     if (!isValidId(orgId)) {
         return Promise.resolve(null);
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}`, "GET").then((httpResponse) => {
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "GET").then((httpResponse) => {
         if (httpResponse.statusCode === 401) {
-            throw new Error("apiKey is incorrect")
+            throw new Error("integrationApiKey is incorrect")
         } else if (httpResponse.statusCode === 404) {
             return null
         } else if (httpResponse.statusCode === 426) {
@@ -144,16 +144,16 @@ export type OrgQueryResponse = {
     hasMoreResults: boolean,
 }
 
-export function fetchOrgByQuery(authUrl: URL, apiKey: string, query: OrgQuery): Promise<OrgQueryResponse> {
+export function fetchOrgByQuery(authUrl: URL, integrationApiKey: string, query: OrgQuery): Promise<OrgQueryResponse> {
     const request = {
         page_size: query.pageSize,
         page_number: query.pageNumber,
         order_by: query.orderBy,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/query`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/query`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode === 426) {
@@ -200,7 +200,7 @@ export type UsersPagedResponse = {
     hasMoreResults: boolean
 }
 
-export function fetchUsersByQuery(authUrl: URL, apiKey: string, query: UsersQuery): Promise<UsersPagedResponse> {
+export function fetchUsersByQuery(authUrl: URL, integrationApiKey: string, query: UsersQuery): Promise<UsersPagedResponse> {
     const queryParams = {
         page_size: query.pageSize,
         page_number: query.pageNumber,
@@ -209,10 +209,10 @@ export function fetchUsersByQuery(authUrl: URL, apiKey: string, query: UsersQuer
         include_orgs: query.includeOrgs,
     }
     const q = formatQueryParameters(queryParams)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/query?${q}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/query?${q}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -230,7 +230,7 @@ export type UsersInOrgQuery = {
     includeOrgs?: boolean,
 }
 
-export function fetchUsersInOrg(authUrl: URL, apiKey: string, query: UsersInOrgQuery): Promise<UsersPagedResponse> {
+export function fetchUsersInOrg(authUrl: URL, integrationApiKey: string, query: UsersInOrgQuery): Promise<UsersPagedResponse> {
     if (!isValidId(query.orgId)) {
         const emptyResponse: UsersPagedResponse = {
             users: [],
@@ -248,10 +248,10 @@ export function fetchUsersInOrg(authUrl: URL, apiKey: string, query: UsersInOrgQ
         include_orgs: query.includeOrgs,
     }
     const queryString = formatQueryParameters(queryParams)
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/org/${query.orgId}?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/org/${query.orgId}?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new Error("Invalid query " + httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -275,7 +275,7 @@ export type CreateUserRequest = {
     lastName?: string,
 }
 
-export function createUser(authUrl: URL, apiKey: string, createUserRequest: CreateUserRequest): Promise<User> {
+export function createUser(authUrl: URL, integrationApiKey: string, createUserRequest: CreateUserRequest): Promise<User> {
     const request = {
         email: createUserRequest.email,
         email_confirmed: createUserRequest.emailConfirmed,
@@ -288,10 +288,10 @@ export function createUser(authUrl: URL, apiKey: string, createUserRequest: Crea
         first_name: createUserRequest.firstName,
         last_name: createUserRequest.lastName,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -310,7 +310,7 @@ export type UpdateUserMetadataRequest = {
     metadata?: {[key: string]: any}
 }
 
-export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
+export function updateUserMetadata(authUrl: URL, integrationApiKey: string, userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -322,10 +322,10 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         picture_url: updateUserMetadataRequest.pictureUrl,
         metadata: updateUserMetadataRequest.metadata,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserMetadataException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -338,15 +338,15 @@ export function updateUserMetadata(authUrl: URL, apiKey: string, userId: string,
         })
 }
 
-export function deleteUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function deleteUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}`, "DELETE")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -357,15 +357,15 @@ export function deleteUser(authUrl: URL, apiKey: string, userId: string): Promis
         })
 }
 
-export function disableUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function disableUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/disable`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -376,15 +376,15 @@ export function disableUser(authUrl: URL, apiKey: string, userId: string): Promi
         })
 }
 
-export function enableUser(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function enableUser(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/enable`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/enable`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -395,15 +395,15 @@ export function enableUser(authUrl: URL, apiKey: string, userId: string): Promis
         })
 }
 
-export function disableUser2fa(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function disableUser2fa(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/disable_2fa`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/disable_2fa`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -419,7 +419,7 @@ export type UpdateUserEmailRequest = {
     requireEmailConfirmation: boolean,
 }
 
-export function updateUserEmail(authUrl: URL, apiKey: string, userId: string, updateUserEmail: UpdateUserEmailRequest): Promise<boolean> {
+export function updateUserEmail(authUrl: URL, integrationApiKey: string, userId: string, updateUserEmail: UpdateUserEmailRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -428,10 +428,10 @@ export function updateUserEmail(authUrl: URL, apiKey: string, userId: string, up
         new_email: updateUserEmail.newEmail,
         require_email_confirmation: updateUserEmail.requireEmailConfirmation,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/email`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/email`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserEmailException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -449,7 +449,7 @@ export type UpdateUserPasswordRequest = {
     askUserToUpdatePasswordOnLogin?: boolean,
 }
 
-export function updateUserPassword(authUrl: URL, apiKey: string, userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
+export function updateUserPassword(authUrl: URL, integrationApiKey: string, userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
@@ -458,10 +458,10 @@ export function updateUserPassword(authUrl: URL, apiKey: string, userId: string,
         password: updateUserPasswordRequest.password,
         ask_user_to_update_password_on_login: updateUserPasswordRequest.askUserToUpdatePasswordOnLogin,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/password`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/password`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateUserPasswordException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -474,15 +474,15 @@ export function updateUserPassword(authUrl: URL, apiKey: string, userId: string,
         })
 }
 
-export function enableUserCanCreateOrgs(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function enableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/can_create_orgs/enable`, "PUT")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/enable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -493,15 +493,15 @@ export function enableUserCanCreateOrgs(authUrl: URL, apiKey: string, userId: st
         })
 }
 
-export function disableUserCanCreateOrgs(authUrl: URL, apiKey: string, userId: string): Promise<boolean> {
+export function disableUserCanCreateOrgs(authUrl: URL, integrationApiKey: string, userId: string): Promise<boolean> {
     if (!isValidId(userId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/user/${userId}/can_create_orgs/disable`, "PUT")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/user/${userId}/can_create_orgs/disable`, "PUT")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -524,17 +524,17 @@ export type MagicLink = {
     url: string
 }
 
-export function createMagicLink(authUrl: URL, apiKey: string, createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
+export function createMagicLink(authUrl: URL, integrationApiKey: string, createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
     const request = {
         email: createMagicLinkRequest.email,
         redirect_to_url: createMagicLinkRequest.redirectToUrl,
         expires_in_hours: createMagicLinkRequest.expiresInHours,
         create_new_user_if_one_doesnt_exist: createMagicLinkRequest.createNewUserIfOneDoesntExist,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/magic_link`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/magic_link`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new MagicLinkCreationException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -554,7 +554,7 @@ export type AccessToken = {
     access_token: string
 }
 
-export function createAccessToken(authUrl: URL, apiKey: string, createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
+export function createAccessToken(authUrl: URL, integrationApiKey: string, createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
     if (!isValidId(createAccessTokenRequest.userId)) {
         throw new UserNotFoundException()
     }
@@ -563,10 +563,10 @@ export function createAccessToken(authUrl: URL, apiKey: string, createAccessToke
         user_id: createAccessTokenRequest.userId,
         duration_in_minutes: createAccessTokenRequest.durationInMinutes,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/access_token`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/access_token`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new AccessTokenCreationException(httpResponse.response)
             } else if (httpResponse.statusCode === 403) {
@@ -598,7 +598,7 @@ export type MigrateUserFromExternalSourceRequest = {
 }
 
 export function migrateUserFromExternalSource(authUrl: URL,
-                                              apiKey: string,
+                                              integrationApiKey: string,
                                               migrateUserFromExternalSourceRequest: MigrateUserFromExternalSourceRequest): Promise<User> {
     const request = {
         email: migrateUserFromExternalSourceRequest.email,
@@ -615,10 +615,10 @@ export function migrateUserFromExternalSource(authUrl: URL,
         last_name: migrateUserFromExternalSourceRequest.lastName,
         username: migrateUserFromExternalSourceRequest.username,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/migrate_user/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/migrate_user/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new MigrateUserException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -633,14 +633,14 @@ export type CreateOrgRequest = {
     name: string
 }
 
-export function createOrg(authUrl: URL, apiKey: string, createOrgRequest: CreateOrgRequest): Promise<Org> {
+export function createOrg(authUrl: URL, integrationApiKey: string, createOrgRequest: CreateOrgRequest): Promise<Org> {
     const request = {
         name: createOrgRequest.name,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new CreateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -657,16 +657,16 @@ export type AddUserToOrgRequest = {
     role: string
 }
 
-export function addUserToOrg(authUrl: URL, apiKey: string, addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
+export function addUserToOrg(authUrl: URL, integrationApiKey: string, addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
     const request = {
         user_id: addUserToOrgRequest.userId,
         org_id: addUserToOrgRequest.orgId,
         role: addUserToOrgRequest.role,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/add_user`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/add_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new AddUserToOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -685,16 +685,16 @@ export type ChangeUserRoleInOrgRequest = {
     role: string
 }
 
-export function changeUserRoleInOrg(authUrl: URL, apiKey: string, changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
+export function changeUserRoleInOrg(authUrl: URL, integrationApiKey: string, changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
     const request = {
         user_id: changeUserRoleInOrgRequest.userId,
         org_id: changeUserRoleInOrgRequest.orgId,
         role: changeUserRoleInOrgRequest.role,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/change_role`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/change_role`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new ChangeUserRoleInOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -712,15 +712,15 @@ export type RemoveUserFromOrgRequest = {
     orgId: string
 }
 
-export function removeUserFromOrg(authUrl: URL, apiKey: string, removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
+export function removeUserFromOrg(authUrl: URL, integrationApiKey: string, removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
     const request = {
         user_id: removeUserFromOrgRequest.userId,
         org_id: removeUserFromOrgRequest.orgId,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/remove_user`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/remove_user`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new RemoveUserFromOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -741,7 +741,7 @@ export type UpdateOrgRequest = {
     metadata?: {[key: string]: any}
 }
 
-export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
+export function updateOrg(authUrl: URL, integrationApiKey: string, updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
     if (!isValidId(updateOrgRequest.orgId)) {
         return Promise.resolve(false)
     }
@@ -752,10 +752,10 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
         metadata: updateOrgRequest.metadata,
         max_users: updateOrgRequest.maxUsers,
     }
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${updateOrgRequest.orgId}`, "PUT", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
                 throw new UpdateOrgException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
@@ -768,15 +768,15 @@ export function updateOrg(authUrl: URL, apiKey: string, updateOrgRequest: Update
         })
 }
 
-export function deleteOrg(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function deleteOrg(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}`, "DELETE")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -788,15 +788,15 @@ export function deleteOrg(authUrl: URL, apiKey: string, orgId: string): Promise<
 }
 
 
-export function allowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function allowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}/allow_saml`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/allow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -807,15 +807,15 @@ export function allowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgI
         })
 }
 
-export function disallowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, orgId: string): Promise<boolean> {
+export function disallowOrgToSetupSamlConnection(authUrl: URL, integrationApiKey: string, orgId: string): Promise<boolean> {
     if (!isValidId(orgId)) {
         return Promise.resolve(false)
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/org/${orgId}/disallow_saml`, "POST")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/org/${orgId}/disallow_saml`, "POST")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
@@ -828,22 +828,26 @@ export function disallowOrgToSetupSamlConnection(authUrl: URL, apiKey: string, o
 
 // functions for managing end user api keys
 
-export function fetchEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey: string): Promise<EndUserApiKeyFull> {
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys/${endUserApiKey}`, "GET")
+export function fetchApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<ApiKeyFull> {
+    if (!isValidHex(apiKey)) {
+        throw new ApiKeyFetchException("Invalid api key")
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyFetchException(httpResponse.response)
+                throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when creating the end user api key")
+                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
         })
 }
 
-export type EndUserApiKeysQueryRequest = {
+export type ApiKeysQueryRequest = {
     orgId?: string
     userId?: string
     userEmail?: string
@@ -851,48 +855,48 @@ export type EndUserApiKeysQueryRequest = {
     pageNumber?: number
 }
 
-export function fetchCurrentEndUserApiKeys(authUrl: URL, apiKey: string, endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
+export function fetchCurrentApiKeys(authUrl: URL, integrationApiKey: string, apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
     const request = {
-        org_id: endUserApiKeyQuery.orgId,
-        user_id: endUserApiKeyQuery.userId,
-        user_email: endUserApiKeyQuery.userEmail,
-        page_size: endUserApiKeyQuery.pageSize,
-        page_number: endUserApiKeyQuery.pageNumber,
+        org_id: apiKeyQuery.orgId,
+        user_id: apiKeyQuery.userId,
+        user_email: apiKeyQuery.userEmail,
+        page_size: apiKeyQuery.pageSize,
+        page_number: apiKeyQuery.pageNumber,
     }
     const queryString = formatQueryParameters(request)
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/archived?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyFetchException(httpResponse.response)
+                throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when creating the end user api key")
+                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
         })
 }
 
-export function fetchArchivedEndUserApiKeys(authUrl: URL, apiKey: string, endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
+export function fetchArchivedApiKeys(authUrl: URL, integrationApiKey: string, apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
     const request = {
-        org_id: endUserApiKeyQuery.orgId,
-        user_id: endUserApiKeyQuery.userId,
-        user_email: endUserApiKeyQuery.userEmail,
-        page_size: endUserApiKeyQuery.pageSize,
-        page_number: endUserApiKeyQuery.pageNumber,
+        org_id: apiKeyQuery.orgId,
+        user_id: apiKeyQuery.userId,
+        user_email: apiKeyQuery.userEmail,
+        page_size: apiKeyQuery.pageSize,
+        page_number: apiKeyQuery.pageNumber,
     }
     const queryString = formatQueryParameters(request)
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys?${queryString}`, "GET")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyFetchException(httpResponse.response)
+                throw new ApiKeyFetchException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when creating the end user api key")
+                throw new ApiKeyFetchException("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -900,88 +904,100 @@ export function fetchArchivedEndUserApiKeys(authUrl: URL, apiKey: string, endUse
 }
 
 
-export type EndUserApiKeysCreateRequest = {
+export type ApiKeysCreateRequest = {
     orgId?: string
     userId?: string
     expiresAtSeconds?: number
     metadata?: string
 }
-export function createEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKeyCreate: EndUserApiKeysCreateRequest): Promise<EndUserApiKeyNew> {
+export function createApiKey(authUrl: URL, integrationApiKey: string, apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
     const request = {
-        org_id: endUserApiKeyCreate.orgId,
-        user_id: endUserApiKeyCreate.userId,
-        expires_at_seconds: endUserApiKeyCreate.expiresAtSeconds,
-        metadata: endUserApiKeyCreate.metadata,
+        org_id: apiKeyCreate.orgId,
+        user_id: apiKeyCreate.userId,
+        expires_at_seconds: apiKeyCreate.expiresAtSeconds,
+        metadata: apiKeyCreate.metadata,
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys`, "POST", JSON.stringify(request))
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyCreateException(httpResponse.response)
+                throw new ApiKeyCreateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when creating the end user api key")
+                throw new ApiKeyCreateException("Unknown error when creating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
         })
 }
 
-export type EndUserApiKeyUpdateRequest = {
+export type ApiKeyUpdateRequest = {
     expiresAtSeconds?: number
     metadata?: string
 }
-export function updateEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey: string, endUserApiKeyUpdate: EndUserApiKeyUpdateRequest): Promise<boolean> {
-    const request = {
-        expires_at_seconds: endUserApiKeyUpdate.expiresAtSeconds,
-        metadata: endUserApiKeyUpdate.metadata,
+export function updateApiKey(authUrl: URL, integrationApiKey: string, apiKey: string, apiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+    if (!isValidHex(apiKey)) {
+        throw new ApiKeyUpdateException("Invalid api key")
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys/${endUserApiKey}`, "PATCH", JSON.stringify(request))
+    const request = {
+        expires_at_seconds: apiKeyUpdate.expiresAtSeconds,
+        metadata: apiKeyUpdate.metadata,
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "PATCH", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyUpdateException(httpResponse.response)
+                throw new ApiKeyUpdateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when updating the end user api key")
+                throw new ApiKeyUpdateException("Unknown error when updating the end user api key")
             }
 
             return true
         })
 }
 
-export function deleteEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey: string): Promise<boolean> {
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys/${endUserApiKey}`, "DELETE")
+export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<boolean> {
+    if (!isValidHex(apiKey)) {
+        throw new ApiKeyDeleteException("Invalid api key")
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/${apiKey}`, "DELETE")
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyDeleteException(httpResponse.response)
+                throw new ApiKeyDeleteException(httpResponse.response)
             } else if (httpResponse.statusCode === 404) {
                 return false
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when deleting the end user api key")
+                throw new ApiKeyDeleteException("Unknown error when deleting the end user api key")
             }
 
             return true
         })
 }
 
-export function validateEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKey: string): Promise<EndUserApiKeyValidation> {
-    const request = {
-        api_key_token: endUserApiKey,
+export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKey: string): Promise<ApiKeyValidation> {
+    if (!isValidHex(apiKey)) {
+        throw new ApiKeyValidateException("Invalid api key")
     }
 
-    return httpRequest(authUrl, apiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
+    const request = {
+        api_key_token: apiKey,
+    }
+
+    return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))
         .then((httpResponse) => {
             if (httpResponse.statusCode === 401) {
-                throw new Error("apiKey is incorrect")
+                throw new Error("integrationApiKey is incorrect")
             } else if (httpResponse.statusCode === 400) {
-                throw new EndUserApiKeyValidateException(httpResponse.response)
+                throw new ApiKeyValidateException(httpResponse.response)
             } else if (httpResponse.statusCode && httpResponse.statusCode >= 400) {
-                throw new Error("Unknown error when updating the end user api key")
+                throw new ApiKeyValidateException("Unknown error when updating the end user api key")
             }
 
             return parseEndUserApiKey(httpResponse.response)
@@ -989,10 +1005,17 @@ export function validateEndUserApiKey(authUrl: URL, apiKey: string, endUserApiKe
 }
 
 const idRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+const hexRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 
 function isValidId(id: string): boolean {
     return idRegex.test(id)
 }
+
+
+function isValidHex(id: string): boolean {
+    return hexRegex.test(id)
+}
+
 
 function formatQueryParameters(obj: { [key: string]: any }): string {
     const params = new URLSearchParams();

--- a/src/api.ts
+++ b/src/api.ts
@@ -981,13 +981,9 @@ export function deleteApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: 
         })
 }
 
-export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyId: string): Promise<ApiKeyValidation> {
-    if (!isValidHex(apiKeyId)) {
-        throw new ApiKeyValidateException("Invalid api key")
-    }
-
+export function validateApiKey(authUrl: URL, integrationApiKey: string, apiKeyToken: string): Promise<ApiKeyValidation> {
     const request = {
-        api_key_token: apiKeyId,
+        api_key_token: apiKeyToken,
     }
 
     return httpRequest(authUrl, integrationApiKey, `/api/backend/v1/end_user_api_keys/validate`, "POST", JSON.stringify(request))

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -263,8 +263,8 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         return deleteApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
-    function validateApiKeyWrapper(apiKeyId: string): Promise<ApiKeyValidation> {
-        return validateApiKey(authUrl, integrationApiKey, apiKeyId)
+    function validateApiKeyWrapper(apiKeyToken: string): Promise<ApiKeyValidation> {
+        return validateApiKey(authUrl, integrationApiKey, apiKeyToken)
     }
 
     return {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -58,12 +58,14 @@ import {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
+    validateEndUserApiKey,
 } from "./api"
 import {ForbiddenException, UnauthorizedException, UnexpectedException} from "./exceptions"
 import {
     EndUserApiKeyFull,
     EndUserApiKeyNew,
     EndUserApiKeyResultPage,
+    EndUserApiKeyValidation,
     InternalUser,
     Org,
     OrgIdToOrgMemberInfo,
@@ -261,6 +263,10 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         return deleteEndUserApiKey(authUrl, apiKey, endUserApiKey)
     }
 
+    function validateEndUserApiKeyWrapper(endUserApiKey: string): Promise<EndUserApiKeyValidation> {
+        return validateEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    }
+
     return {
         // validate and fetching functions
         validateAccessTokenAndGetUser,
@@ -310,6 +316,7 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         createEndUserApiKey: createEndUserApiKeyWrapper,
         updateEndUserApiKey: updateEndUserApiKeyWrapper,
         deleteEndUserApiKey: deleteEndUserApiKeyWrapper,
+        validateEndUserApiKey: validateEndUserApiKeyWrapper,
     }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -239,32 +239,32 @@ export function initBaseAuth(opts: BaseAuthOptions) {
     }
 
     // end user api key wrappers
-    function fetchApiKeyWrapper(ApiKey: string): Promise<ApiKeyFull> {
-        return fetchApiKey(authUrl, integrationApiKey, ApiKey)
+    function fetchApiKeyWrapper(apiKeyId: string): Promise<ApiKeyFull> {
+        return fetchApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
-    function fetchCurrentApiKeysWrapper(ApiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
-        return fetchCurrentApiKeys(authUrl, integrationApiKey, ApiKeyQuery)
+    function fetchCurrentApiKeysWrapper(apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchCurrentApiKeys(authUrl, integrationApiKey, apiKeyQuery)
     }
 
-    function fetchArchivedApiKeysWrapper(ApiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
-        return fetchArchivedApiKeys(authUrl, integrationApiKey, ApiKeyQuery)
+    function fetchArchivedApiKeysWrapper(apiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchArchivedApiKeys(authUrl, integrationApiKey, apiKeyQuery)
     }
 
-    function createApiKeyWrapper(ApiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
-        return createApiKey(authUrl, integrationApiKey, ApiKeyCreate)
+    function createApiKeyWrapper(apiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
+        return createApiKey(authUrl, integrationApiKey, apiKeyCreate)
     }
 
-    function updateApiKeyWrapper(ApiKey: string, ApiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
-        return updateApiKey(authUrl, integrationApiKey, ApiKey, ApiKeyUpdate)
+    function updateApiKeyWrapper(apiKeyId: string, ApiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+        return updateApiKey(authUrl, integrationApiKey, apiKeyId, ApiKeyUpdate)
     }
 
-    function deleteApiKeyWrapper(ApiKey: string): Promise<boolean> {
-        return deleteApiKey(authUrl, integrationApiKey, ApiKey)
+    function deleteApiKeyWrapper(apiKeyId: string): Promise<boolean> {
+        return deleteApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
-    function validateApiKeyWrapper(ApiKey: string): Promise<ApiKeyValidation> {
-        return validateApiKey(authUrl, integrationApiKey, ApiKey)
+    function validateApiKeyWrapper(apiKeyId: string): Promise<ApiKeyValidation> {
+        return validateApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
     return {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,14 +8,14 @@ import {
     ChangeUserRoleInOrgRequest,
     createAccessToken,
     CreateAccessTokenRequest,
-    createEndUserApiKey,
+    createApiKey,
     createMagicLink,
     CreateMagicLinkRequest,
     createOrg,
     CreateOrgRequest,
     createUser,
     CreateUserRequest,
-    deleteEndUserApiKey,
+    deleteApiKey,
     deleteOrg,
     deleteUser,
     disableUser,
@@ -24,13 +24,13 @@ import {
     disallowOrgToSetupSamlConnection,
     enableUser,
     enableUserCanCreateOrgs,
-    EndUserApiKeysCreateRequest,
-    EndUserApiKeysQueryRequest,
-    EndUserApiKeyUpdateRequest,
-    fetchArchivedEndUserApiKeys,
+    ApiKeysCreateRequest,
+    ApiKeysQueryRequest,
+    ApiKeyUpdateRequest,
+    fetchArchivedApiKeys,
     fetchBatchUserMetadata,
-    fetchCurrentEndUserApiKeys,
-    fetchEndUserApiKey,
+    fetchCurrentApiKeys,
+    fetchApiKey,
     fetchOrg,
     fetchOrgByQuery,
     fetchTokenVerificationMetadata,
@@ -46,7 +46,7 @@ import {
     removeUserFromOrg,
     RemoveUserFromOrgRequest,
     TokenVerificationMetadata,
-    updateEndUserApiKey,
+    updateApiKey,
     updateOrg,
     UpdateOrgRequest,
     updateUserEmail,
@@ -58,14 +58,14 @@ import {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
-    validateEndUserApiKey,
+    validateApiKey,
 } from "./api"
 import {ForbiddenException, UnauthorizedException, UnexpectedException} from "./exceptions"
 import {
-    EndUserApiKeyFull,
-    EndUserApiKeyNew,
-    EndUserApiKeyResultPage,
-    EndUserApiKeyValidation,
+    ApiKeyFull,
+    ApiKeyNew,
+    ApiKeyResultPage,
+    ApiKeyValidation,
     InternalUser,
     Org,
     OrgIdToOrgMemberInfo,
@@ -97,9 +97,9 @@ export type BaseAuthOptions = {
 
 export function initBaseAuth(opts: BaseAuthOptions) {
     const authUrl: URL = validateAuthUrl(opts.authUrl)
-    const apiKey: string = opts.apiKey
+    const integrationApiKey: string = opts.apiKey
     const tokenVerificationMetadataPromise = fetchTokenVerificationMetadata(
-        authUrl, apiKey, opts.manualTokenVerificationMetadata
+        authUrl, integrationApiKey, opts.manualTokenVerificationMetadata
     ).catch((err) => {
         console.error("Error initializing auth library. ", err)
     })
@@ -112,159 +112,159 @@ export function initBaseAuth(opts: BaseAuthOptions) {
     const validateAccessTokenAndGetUserWithOrgInfoWithAllPermissions = wrapValidateAccessTokenAndGetUserWithOrgInfoWithAllPermissions(tokenVerificationMetadataPromise)
 
     function fetchUserMetadataByUserId(userId: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByUserIdWithIdCheck(authUrl, apiKey, userId, includeOrgs);
+        return fetchUserMetadataByUserIdWithIdCheck(authUrl, integrationApiKey, userId, includeOrgs);
     }
 
     function fetchUserMetadataByEmail(email: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByQuery(authUrl, apiKey, "email", {email: email, include_orgs: includeOrgs || false})
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, "email", {email: email, include_orgs: includeOrgs || false})
     }
 
     function fetchUserMetadataByUsername(username: string, includeOrgs?: boolean): Promise<UserMetadata | null> {
-        return fetchUserMetadataByQuery(authUrl, apiKey, "username", {
+        return fetchUserMetadataByQuery(authUrl, integrationApiKey, "username", {
             username: username,
             include_orgs: includeOrgs || false
         })
     }
 
     function fetchBatchUserMetadataByUserIds(userIds: string[], includeOrgs?: boolean): Promise<{ [userId: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "user_ids", userIds, (x) => x.userId, includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "user_ids", userIds, (x) => x.userId, includeOrgs || false)
     }
 
     function fetchBatchUserMetadataByEmails(emails: string[], includeOrgs?: boolean): Promise<{ [email: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "emails", emails, (x) => x.email, includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "emails", emails, (x) => x.email, includeOrgs || false)
     }
 
     function fetchBatchUserMetadataByUsernames(usernames: string[], includeOrgs?: boolean): Promise<{ [username: string]: UserMetadata }> {
-        return fetchBatchUserMetadata(authUrl, apiKey, "usernames", usernames, (x) => x.username || "", includeOrgs || false)
+        return fetchBatchUserMetadata(authUrl, integrationApiKey, "usernames", usernames, (x) => x.username || "", includeOrgs || false)
     }
 
     function fetchOrgWrapper(orgId: string): Promise<Org | null> {
-        return fetchOrg(authUrl, apiKey, orgId)
+        return fetchOrg(authUrl, integrationApiKey, orgId)
     }
 
     function fetchOrgsByQueryWrapper(orgQuery: OrgQuery): Promise<OrgQueryResponse> {
-        return fetchOrgByQuery(authUrl, apiKey, orgQuery)
+        return fetchOrgByQuery(authUrl, integrationApiKey, orgQuery)
     }
 
     function fetchUsersByQueryWrapper(usersQuery: UsersQuery): Promise<UsersPagedResponse> {
-        return fetchUsersByQuery(authUrl, apiKey, usersQuery)
+        return fetchUsersByQuery(authUrl, integrationApiKey, usersQuery)
     }
 
     function fetchUsersInOrgWrapper(usersInOrgQuery: UsersInOrgQuery): Promise<UsersPagedResponse> {
-        return fetchUsersInOrg(authUrl, apiKey, usersInOrgQuery)
+        return fetchUsersInOrg(authUrl, integrationApiKey, usersInOrgQuery)
     }
 
     function createUserWrapper(createUserRequest: CreateUserRequest): Promise<User> {
-        return createUser(authUrl, apiKey, createUserRequest)
+        return createUser(authUrl, integrationApiKey, createUserRequest)
     }
 
     function updateUserMetadataWrapper(userId: string, updateUserMetadataRequest: UpdateUserMetadataRequest): Promise<boolean> {
-        return updateUserMetadata(authUrl, apiKey, userId, updateUserMetadataRequest)
+        return updateUserMetadata(authUrl, integrationApiKey, userId, updateUserMetadataRequest)
     }
 
     function deleteUserWrapper(userId: string): Promise<boolean> {
-        return deleteUser(authUrl, apiKey, userId)
+        return deleteUser(authUrl, integrationApiKey, userId)
     }
 
     function disableUserWrapper(userId: string): Promise<boolean> {
-        return disableUser(authUrl, apiKey, userId)
+        return disableUser(authUrl, integrationApiKey, userId)
     }
 
     function enableUserWrapper(userId: string): Promise<boolean> {
-        return enableUser(authUrl, apiKey, userId)
+        return enableUser(authUrl, integrationApiKey, userId)
     }
 
     function disableUser2faWrapper(userId: string): Promise<boolean> {
-        return disableUser2fa(authUrl, apiKey, userId)
+        return disableUser2fa(authUrl, integrationApiKey, userId)
     }
 
     function updateUserEmailWrapper(userId: string, updateUserEmailRequest: UpdateUserEmailRequest): Promise<boolean> {
-        return updateUserEmail(authUrl, apiKey, userId, updateUserEmailRequest)
+        return updateUserEmail(authUrl, integrationApiKey, userId, updateUserEmailRequest)
     }
 
     function updateUserPasswordWrapper(userId: string, updateUserPasswordRequest: UpdateUserPasswordRequest): Promise<boolean> {
-        return updateUserPassword(authUrl, apiKey, userId, updateUserPasswordRequest)
+        return updateUserPassword(authUrl, integrationApiKey, userId, updateUserPasswordRequest)
     }
 
     function enableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
-        return enableUserCanCreateOrgs(authUrl, apiKey, userId)
+        return enableUserCanCreateOrgs(authUrl, integrationApiKey, userId)
     }
 
     function disableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
-        return disableUserCanCreateOrgs(authUrl, apiKey, userId)
+        return disableUserCanCreateOrgs(authUrl, integrationApiKey, userId)
     }
 
     function createMagicLinkWrapper(createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
-        return createMagicLink(authUrl, apiKey, createMagicLinkRequest)
+        return createMagicLink(authUrl, integrationApiKey, createMagicLinkRequest)
     }
 
     function createAccessTokenWrapper(createAccessTokenRequest: CreateAccessTokenRequest): Promise<AccessToken> {
-        return createAccessToken(authUrl, apiKey, createAccessTokenRequest)
+        return createAccessToken(authUrl, integrationApiKey, createAccessTokenRequest)
     }
 
     function migrateUserFromExternalSourceWrapper(migrateUserFromExternalSourceRequest: MigrateUserFromExternalSourceRequest): Promise<User> {
-        return migrateUserFromExternalSource(authUrl, apiKey, migrateUserFromExternalSourceRequest)
+        return migrateUserFromExternalSource(authUrl, integrationApiKey, migrateUserFromExternalSourceRequest)
     }
 
     function createOrgWrapper(createOrgRequest: CreateOrgRequest): Promise<Org> {
-        return createOrg(authUrl, apiKey, createOrgRequest)
+        return createOrg(authUrl, integrationApiKey, createOrgRequest)
     }
 
     function addUserToOrgWrapper(addUserToOrgRequest: AddUserToOrgRequest): Promise<boolean> {
-        return addUserToOrg(authUrl, apiKey, addUserToOrgRequest)
+        return addUserToOrg(authUrl, integrationApiKey, addUserToOrgRequest)
     }
 
     function changeUserRoleInOrgWrapper(changeUserRoleInOrgRequest: ChangeUserRoleInOrgRequest): Promise<boolean> {
-        return changeUserRoleInOrg(authUrl, apiKey, changeUserRoleInOrgRequest)
+        return changeUserRoleInOrg(authUrl, integrationApiKey, changeUserRoleInOrgRequest)
     }
 
     function removeUserFromOrgWrapper(removeUserFromOrgRequest: RemoveUserFromOrgRequest): Promise<boolean> {
-        return removeUserFromOrg(authUrl, apiKey, removeUserFromOrgRequest)
+        return removeUserFromOrg(authUrl, integrationApiKey, removeUserFromOrgRequest)
     }
 
     function updateOrgWrapper(updateOrgRequest: UpdateOrgRequest): Promise<boolean> {
-        return updateOrg(authUrl, apiKey, updateOrgRequest)
+        return updateOrg(authUrl, integrationApiKey, updateOrgRequest)
     }
 
     function deleteOrgWrapper(orgId: string): Promise<boolean> {
-        return deleteOrg(authUrl, apiKey, orgId)
+        return deleteOrg(authUrl, integrationApiKey, orgId)
     }
 
     function allowOrgToSetupSamlConnectionWrapper(orgId: string): Promise<boolean> {
-        return allowOrgToSetupSamlConnection(authUrl, apiKey, orgId)
+        return allowOrgToSetupSamlConnection(authUrl, integrationApiKey, orgId)
     }
 
     function disallowOrgToSetupSamlConnectionWrapper(orgId: string): Promise<boolean> {
-        return disallowOrgToSetupSamlConnection(authUrl, apiKey, orgId)
+        return disallowOrgToSetupSamlConnection(authUrl, integrationApiKey, orgId)
     }
 
     // end user api key wrappers
-    function fetchEndUserApiKeyWrapper(endUserApiKey: string): Promise<EndUserApiKeyFull> {
-        return fetchEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    function fetchApiKeyWrapper(ApiKey: string): Promise<ApiKeyFull> {
+        return fetchApiKey(authUrl, integrationApiKey, ApiKey)
     }
 
-    function fetchCurrentEndUserApiKeysWrapper(endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
-        return fetchCurrentEndUserApiKeys(authUrl, apiKey, endUserApiKeyQuery)
+    function fetchCurrentApiKeysWrapper(ApiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchCurrentApiKeys(authUrl, integrationApiKey, ApiKeyQuery)
     }
 
-    function fetchArchivedEndUserApiKeysWrapper(endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
-        return fetchArchivedEndUserApiKeys(authUrl, apiKey, endUserApiKeyQuery)
+    function fetchArchivedApiKeysWrapper(ApiKeyQuery: ApiKeysQueryRequest): Promise<ApiKeyResultPage> {
+        return fetchArchivedApiKeys(authUrl, integrationApiKey, ApiKeyQuery)
     }
 
-    function createEndUserApiKeyWrapper(endUserApiKeyCreate: EndUserApiKeysCreateRequest): Promise<EndUserApiKeyNew> {
-        return createEndUserApiKey(authUrl, apiKey, endUserApiKeyCreate)
+    function createApiKeyWrapper(ApiKeyCreate: ApiKeysCreateRequest): Promise<ApiKeyNew> {
+        return createApiKey(authUrl, integrationApiKey, ApiKeyCreate)
     }
 
-    function updateEndUserApiKeyWrapper(endUserApiKey: string, endUserApiKeyUpdate: EndUserApiKeyUpdateRequest): Promise<boolean> {
-        return updateEndUserApiKey(authUrl, apiKey, endUserApiKey, endUserApiKeyUpdate)
+    function updateApiKeyWrapper(ApiKey: string, ApiKeyUpdate: ApiKeyUpdateRequest): Promise<boolean> {
+        return updateApiKey(authUrl, integrationApiKey, ApiKey, ApiKeyUpdate)
     }
 
-    function deleteEndUserApiKeyWrapper(endUserApiKey: string): Promise<boolean> {
-        return deleteEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    function deleteApiKeyWrapper(ApiKey: string): Promise<boolean> {
+        return deleteApiKey(authUrl, integrationApiKey, ApiKey)
     }
 
-    function validateEndUserApiKeyWrapper(endUserApiKey: string): Promise<EndUserApiKeyValidation> {
-        return validateEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    function validateApiKeyWrapper(ApiKey: string): Promise<ApiKeyValidation> {
+        return validateApiKey(authUrl, integrationApiKey, ApiKey)
     }
 
     return {
@@ -309,14 +309,14 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         deleteOrg: deleteOrgWrapper,
         allowOrgToSetupSamlConnection: allowOrgToSetupSamlConnectionWrapper,
         disallowOrgToSetupSamlConnection: disallowOrgToSetupSamlConnectionWrapper,
-        // end user api keys functions
-        fetchEndUserApiKey: fetchEndUserApiKeyWrapper,
-        fetchCurrentEndUserApiKeys: fetchCurrentEndUserApiKeysWrapper,
-        fetchArchivedEndUserApiKeys: fetchArchivedEndUserApiKeysWrapper,
-        createEndUserApiKey: createEndUserApiKeyWrapper,
-        updateEndUserApiKey: updateEndUserApiKeyWrapper,
-        deleteEndUserApiKey: deleteEndUserApiKeyWrapper,
-        validateEndUserApiKey: validateEndUserApiKeyWrapper,
+        // api keys functions
+        fetchApiKey: fetchApiKeyWrapper,
+        fetchCurrentApiKeys: fetchCurrentApiKeysWrapper,
+        fetchArchivedApiKeys: fetchArchivedApiKeysWrapper,
+        createApiKey: createApiKeyWrapper,
+        updateApiKey: updateApiKeyWrapper,
+        deleteApiKey: deleteApiKeyWrapper,
+        validateApiKey: validateApiKeyWrapper,
     }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,19 +8,29 @@ import {
     ChangeUserRoleInOrgRequest,
     createAccessToken,
     CreateAccessTokenRequest,
+    createEndUserApiKey,
     createMagicLink,
     CreateMagicLinkRequest,
     createOrg,
     CreateOrgRequest,
     createUser,
     CreateUserRequest,
+    deleteEndUserApiKey,
     deleteOrg,
     deleteUser,
     disableUser,
     disableUser2fa,
+    disableUserCanCreateOrgs,
     disallowOrgToSetupSamlConnection,
     enableUser,
+    enableUserCanCreateOrgs,
+    EndUserApiKeysCreateRequest,
+    EndUserApiKeysQueryRequest,
+    EndUserApiKeyUpdateRequest,
+    fetchArchivedEndUserApiKeys,
     fetchBatchUserMetadata,
+    fetchCurrentEndUserApiKeys,
+    fetchEndUserApiKey,
     fetchOrg,
     fetchOrgByQuery,
     fetchTokenVerificationMetadata,
@@ -36,6 +46,7 @@ import {
     removeUserFromOrg,
     RemoveUserFromOrgRequest,
     TokenVerificationMetadata,
+    updateEndUserApiKey,
     updateOrg,
     UpdateOrgRequest,
     updateUserEmail,
@@ -48,8 +59,11 @@ import {
     UsersPagedResponse,
     UsersQuery,
 } from "./api"
-import {UnauthorizedException, UnexpectedException, ForbiddenException} from "./exceptions"
+import {ForbiddenException, UnauthorizedException, UnexpectedException} from "./exceptions"
 import {
+    EndUserApiKeyFull,
+    EndUserApiKeyNew,
+    EndUserApiKeyResultPage,
     InternalUser,
     Org,
     OrgIdToOrgMemberInfo,
@@ -170,6 +184,14 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         return updateUserPassword(authUrl, apiKey, userId, updateUserPasswordRequest)
     }
 
+    function enableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
+        return enableUserCanCreateOrgs(authUrl, apiKey, userId)
+    }
+
+    function disableUserCanCreateOrgsWrapper(userId: string): Promise<boolean> {
+        return disableUserCanCreateOrgs(authUrl, apiKey, userId)
+    }
+
     function createMagicLinkWrapper(createMagicLinkRequest: CreateMagicLinkRequest): Promise<MagicLink> {
         return createMagicLink(authUrl, apiKey, createMagicLinkRequest)
     }
@@ -214,6 +236,31 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         return disallowOrgToSetupSamlConnection(authUrl, apiKey, orgId)
     }
 
+    // end user api key wrappers
+    function fetchEndUserApiKeyWrapper(endUserApiKey: string): Promise<EndUserApiKeyFull> {
+        return fetchEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    }
+
+    function fetchCurrentEndUserApiKeysWrapper(endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
+        return fetchCurrentEndUserApiKeys(authUrl, apiKey, endUserApiKeyQuery)
+    }
+
+    function fetchArchivedEndUserApiKeysWrapper(endUserApiKeyQuery: EndUserApiKeysQueryRequest): Promise<EndUserApiKeyResultPage> {
+        return fetchArchivedEndUserApiKeys(authUrl, apiKey, endUserApiKeyQuery)
+    }
+
+    function createEndUserApiKeyWrapper(endUserApiKeyCreate: EndUserApiKeysCreateRequest): Promise<EndUserApiKeyNew> {
+        return createEndUserApiKey(authUrl, apiKey, endUserApiKeyCreate)
+    }
+
+    function updateEndUserApiKeyWrapper(endUserApiKey: string, endUserApiKeyUpdate: EndUserApiKeyUpdateRequest): Promise<boolean> {
+        return updateEndUserApiKey(authUrl, apiKey, endUserApiKey, endUserApiKeyUpdate)
+    }
+
+    function deleteEndUserApiKeyWrapper(endUserApiKey: string): Promise<boolean> {
+        return deleteEndUserApiKey(authUrl, apiKey, endUserApiKey)
+    }
+
     return {
         // validate and fetching functions
         validateAccessTokenAndGetUser,
@@ -245,7 +292,8 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         disableUser: disableUserWrapper,
         enableUser: enableUserWrapper,
         disableUser2fa: disableUser2faWrapper,
-
+        enableUserCanCreateOrgs: enableUserCanCreateOrgsWrapper,
+        disableUserCanCreateOrgs: disableUserCanCreateOrgsWrapper,
         // org management functions
         createOrg: createOrgWrapper,
         addUserToOrg: addUserToOrgWrapper,
@@ -255,6 +303,13 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         deleteOrg: deleteOrgWrapper,
         allowOrgToSetupSamlConnection: allowOrgToSetupSamlConnectionWrapper,
         disallowOrgToSetupSamlConnection: disallowOrgToSetupSamlConnectionWrapper,
+        // end user api keys functions
+        fetchEndUserApiKey: fetchEndUserApiKeyWrapper,
+        fetchCurrentEndUserApiKeys: fetchCurrentEndUserApiKeysWrapper,
+        fetchArchivedEndUserApiKeys: fetchArchivedEndUserApiKeysWrapper,
+        createEndUserApiKey: createEndUserApiKeyWrapper,
+        updateEndUserApiKey: updateEndUserApiKeyWrapper,
+        deleteEndUserApiKey: deleteEndUserApiKeyWrapper,
     }
 }
 

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -126,3 +126,43 @@ export class UpdateUserMetadataException extends Error {
 
 export class UserNotFoundException extends Error {
 }
+
+export class EndUserApiKeyValidateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class EndUserApiKeyDeleteException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class EndUserApiKeyUpdateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class EndUserApiKeyCreateException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}
+
+export class EndUserApiKeyFetchException extends Error {
+    readonly fieldToErrors: {[fieldName: string]: string[]};
+    constructor(message: string) {
+        super(message);
+        this.fieldToErrors = JSON.parse(message);
+    }
+}

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -127,7 +127,7 @@ export class UpdateUserMetadataException extends Error {
 export class UserNotFoundException extends Error {
 }
 
-export class EndUserApiKeyValidateException extends Error {
+export class ApiKeyValidateException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
         super(message);
@@ -135,7 +135,7 @@ export class EndUserApiKeyValidateException extends Error {
     }
 }
 
-export class EndUserApiKeyDeleteException extends Error {
+export class ApiKeyDeleteException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
         super(message);
@@ -143,7 +143,7 @@ export class EndUserApiKeyDeleteException extends Error {
     }
 }
 
-export class EndUserApiKeyUpdateException extends Error {
+export class ApiKeyUpdateException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
         super(message);
@@ -151,7 +151,7 @@ export class EndUserApiKeyUpdateException extends Error {
     }
 }
 
-export class EndUserApiKeyCreateException extends Error {
+export class ApiKeyCreateException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
         super(message);
@@ -159,7 +159,7 @@ export class EndUserApiKeyCreateException extends Error {
     }
 }
 
-export class EndUserApiKeyFetchException extends Error {
+export class ApiKeyFetchException extends Error {
     readonly fieldToErrors: {[fieldName: string]: string[]};
     constructor(message: string) {
         super(message);

--- a/src/user.ts
+++ b/src/user.ts
@@ -179,12 +179,12 @@ export function toOrgIdToOrgMemberInfo(snake_case?: {
 }
 
 
-export type EndUserApiKeyNew ={
+export type ApiKeyNew ={
     apiKeyId: string
     apiKeyToken: string
 }
 
-export type EndUserApiKeyFull = {
+export type ApiKeyFull = {
     apiKeyId: string
     createdAt: number
     expiresAtSeconds: number
@@ -193,15 +193,15 @@ export type EndUserApiKeyFull = {
     orgId: string
 }
 
-export type EndUserApiKeyResultPage = {
-    apiKeys: EndUserApiKeyFull[]
+export type ApiKeyResultPage = {
+    apiKeys: ApiKeyFull[]
     totalApiKeys: number
     currentPage: number
     pageSize: number
     hasMoreResults: boolean
 }
 
-export type EndUserApiKeyValidation = {
+export type ApiKeyValidation = {
     metadata?: {[key: string]: any}
     userMetadata?: {[key: string]: any}
     orgMetadata?: {[key: string]: any}

--- a/src/user.ts
+++ b/src/user.ts
@@ -18,6 +18,7 @@ export type User = {
 export type Org = {
     orgId: string,
     name: string,
+    maxUsers?: number,
 }
 
 export type UserMetadata = {
@@ -34,6 +35,7 @@ export type UserMetadata = {
     locked: boolean,
     enabled: boolean,
     mfaEnabled: boolean,
+    canCreateOrgs: boolean,
 
     createdAt: number,
     lastActiveAt: number,
@@ -174,4 +176,34 @@ export function toOrgIdToOrgMemberInfo(snake_case?: {
     }
 
     return camelCase
+}
+
+
+export type EndUserApiKeyNew ={
+    apiKeyId: string
+    apiKeyToken: string
+}
+
+export type EndUserApiKeyFull = {
+    apiKeyId: string
+    createdAt: number
+    expiresAtSeconds: number
+    metadata: {[key: string]: any}
+    userId: string
+    orgId: string
+}
+
+export type EndUserApiKeyResultPage = {
+    apiKeys: EndUserApiKeyFull[]
+    totalApiKeys: number
+    currentPage: number
+    pageSize: number
+    hasMoreResults: boolean
+}
+
+export type EndUserApiKeyValidation = {
+    metadata?: {[key: string]: any}
+    userMetadata?: {[key: string]: any}
+    orgMetadata?: {[key: string]: any}
+    userRoleInOrg?: string
 }


### PR DESCRIPTION
## Set the maximum users in an org

Set the maximum number of users an org can have with the new **max_users** property on the Org object. Set it with the usual updateOrg() function, and see the current value with fetchOrg(). It's an optional field, and if it's missing orgs will continue to allow unlimited users.

## Let only certain users create orgs

Users can be given permission to create orgs through **enableUserCanCreateOrgs**, and that permission can be removed with **disableUserCanCreateOrgs**. This special permission overrides the realm-wide users_can_create_orgs. With this new functionality, you can turn off org creation in general, and only grant certain users the privilege. (If the realm-wide users_can_create_orgs is on, then everyone will always be able to create orgs.)

## API Keys

A whole host of functions for managing API Keys. These aren't the Integration API Keys you use to communicate with PropelAuth (in this very library), these are API Keys that you can give out to your own clients. We'll happily manage them for you. You can set the optional user, an optional org, optional metadata, and an expiration.

These new API Key endpoints are:

- **fetchApiKey**
- **fetchCurrentApiKeys**
- **fetchArchivedApiKeys**
- **createApiKey**
- **updateApiKey**
- **deleteApiKey**
- **validateApiKey**
