### PR TITLE
Distinguish Personal from Org API Keys

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,29 +4,31 @@ import {
     ApiKeyNew,
     ApiKeyResultPage,
     ApiKeyValidation,
-    Org, OrgApiKeyValidation, PersonalApiKeyValidation,
+    Org,
+    OrgApiKeyValidation,
+    PersonalApiKeyValidation,
     User,
     UserMetadata
 } from "./user"
 import {
+    AccessTokenCreationException,
+    AddUserToOrgException,
+    ApiKeyCreateException,
+    ApiKeyDeleteException,
+    ApiKeyFetchException,
+    ApiKeyUpdateException,
+    ApiKeyValidateException,
+    ChangeUserRoleInOrgException,
+    CreateOrgException,
     CreateUserException,
-    UpdateUserMetadataException,
-    UpdateUserEmailException,
     MagicLinkCreationException,
     MigrateUserException,
-    CreateOrgException,
-    AddUserToOrgException,
-    UpdateUserPasswordException,
-    ChangeUserRoleInOrgException,
     RemoveUserFromOrgException,
     UpdateOrgException,
-    AccessTokenCreationException,
-    UserNotFoundException,
-    ApiKeyFetchException,
-    ApiKeyCreateException,
-    ApiKeyUpdateException,
-    ApiKeyDeleteException,
-    ApiKeyValidateException, UnauthorizedException
+    UpdateUserEmailException,
+    UpdateUserMetadataException,
+    UpdateUserPasswordException,
+    UserNotFoundException
 } from "./exceptions";
 
 export type TokenVerificationMetadata = {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,6 +4,9 @@ import {
     addUserToOrg,
     AddUserToOrgRequest,
     allowOrgToSetupSamlConnection,
+    ApiKeysCreateRequest,
+    ApiKeysQueryRequest,
+    ApiKeyUpdateRequest,
     changeUserRoleInOrg,
     ChangeUserRoleInOrgRequest,
     createAccessToken,
@@ -24,13 +27,10 @@ import {
     disallowOrgToSetupSamlConnection,
     enableUser,
     enableUserCanCreateOrgs,
-    ApiKeysCreateRequest,
-    ApiKeysQueryRequest,
-    ApiKeyUpdateRequest,
+    fetchApiKey,
     fetchArchivedApiKeys,
     fetchBatchUserMetadata,
     fetchCurrentApiKeys,
-    fetchApiKey,
     fetchOrg,
     fetchOrgByQuery,
     fetchTokenVerificationMetadata,
@@ -58,7 +58,7 @@ import {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
-    validateApiKey,
+    validateApiKey, validateOrgApiKey, validatePersonalApiKey,
 } from "./api"
 import {ForbiddenException, UnauthorizedException, UnexpectedException} from "./exceptions"
 import {
@@ -67,9 +67,9 @@ import {
     ApiKeyResultPage,
     ApiKeyValidation,
     InternalUser,
-    Org,
+    Org, OrgApiKeyValidation,
     OrgIdToOrgMemberInfo,
-    OrgMemberInfo,
+    OrgMemberInfo, PersonalApiKeyValidation,
     toUser,
     User,
     UserAndOrgMemberInfo,
@@ -263,6 +263,14 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         return deleteApiKey(authUrl, integrationApiKey, apiKeyId)
     }
 
+    function validatePersonalApiKeyWrapper(apiKeyToken: string): Promise<PersonalApiKeyValidation> {
+        return validatePersonalApiKey(authUrl, integrationApiKey, apiKeyToken)
+    }
+
+    function validateOrgApiKeyWrapper(apiKeyToken: string): Promise<OrgApiKeyValidation> {
+        return validateOrgApiKey(authUrl, integrationApiKey, apiKeyToken)
+    }
+
     function validateApiKeyWrapper(apiKeyToken: string): Promise<ApiKeyValidation> {
         return validateApiKey(authUrl, integrationApiKey, apiKeyToken)
     }
@@ -317,6 +325,8 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         updateApiKey: updateApiKeyWrapper,
         deleteApiKey: deleteApiKeyWrapper,
         validateApiKey: validateApiKeyWrapper,
+        validatePersonalApiKey: validatePersonalApiKeyWrapper,
+        validateOrgApiKey: validateOrgApiKeyWrapper,
     }
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -58,7 +58,9 @@ import {
     UsersInOrgQuery,
     UsersPagedResponse,
     UsersQuery,
-    validateApiKey, validateOrgApiKey, validatePersonalApiKey,
+    validateApiKey,
+    validateOrgApiKey,
+    validatePersonalApiKey,
 } from "./api"
 import {ForbiddenException, UnauthorizedException, UnexpectedException} from "./exceptions"
 import {
@@ -67,9 +69,11 @@ import {
     ApiKeyResultPage,
     ApiKeyValidation,
     InternalUser,
-    Org, OrgApiKeyValidation,
+    Org,
+    OrgApiKeyValidation,
     OrgIdToOrgMemberInfo,
-    OrgMemberInfo, PersonalApiKeyValidation,
+    OrgMemberInfo,
+    PersonalApiKeyValidation,
     toUser,
     User,
     UserAndOrgMemberInfo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,11 @@ export {
     AccessToken,
 } from "./api"
 export {
+    ApiKeyValidateException,
+    ApiKeyDeleteException,
+    ApiKeyUpdateException,
+    ApiKeyCreateException,
+    ApiKeyFetchException,
     AccessTokenCreationException,
     AddUserToOrgException,
     CreateOrgException,

--- a/src/user.ts
+++ b/src/user.ts
@@ -210,7 +210,7 @@ export type ApiKeyValidation = {
 
 export type PersonalApiKeyValidation = {
     metadata?: {[key: string]: any}
-    user?: UserMetadata,
+    user: UserMetadata,
 }
 
 export type OrgApiKeyValidation = {

--- a/src/user.ts
+++ b/src/user.ts
@@ -203,7 +203,19 @@ export type ApiKeyResultPage = {
 
 export type ApiKeyValidation = {
     metadata?: {[key: string]: any}
-    userMetadata?: {[key: string]: any}
-    orgMetadata?: {[key: string]: any}
-    userRoleInOrg?: string
+    user?: UserMetadata,
+    org?: Org,
+    userInOrg?: OrgMemberInfo
+}
+
+export type PersonalApiKeyValidation = {
+    metadata?: {[key: string]: any}
+    user?: UserMetadata,
+}
+
+export type OrgApiKeyValidation = {
+    metadata?: {[key: string]: any}
+    org: Org,
+    user?: UserMetadata,
+    userInOrg?: OrgMemberInfo
 }


### PR DESCRIPTION
- Clean up the snake => camel case code
- user/org metadata are now real types
- role in org is now the full org_member_info so you can do role/perm checks
- two new validation functions for personal/org keys