### PR TITLE
Update rollup config to target workerd and browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node"
     },
-    "version": "2.1.15",
+    "version": "2.1.16",
     "license": "MIT",
     "keywords": [
         "auth",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,11 @@ export default {
             sourcemap: true,
         },
     ],
-    plugins: [peerDepsExternal(), resolve({ extensions }), commonjs(), typescript()],
+    plugins: [
+        peerDepsExternal(),
+        resolve({ extensions, exportConditions: ["browser", "worker"], browser: true }),
+        commonjs(),
+        typescript(),
+    ],
     external: Object.keys(globals),
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,11 @@ export default {
     ],
     plugins: [
         peerDepsExternal(),
-        resolve({ extensions, exportConditions: ["browser", "worker"], browser: true }),
+        resolve({
+            extensions,
+            exportConditions: ["browser", "worker"],
+            browser: true,
+        }),
         commonjs(),
         typescript(),
     ],


### PR DESCRIPTION
Update rollup.config to target browsers / CF workers runtime. This was copied from the deprecated https://github.com/PropelAuth/cloudflare-worker/blob/main/rollup.config.js package.

I tested this by installing my forked version of the package in my app and deploying it to CF pages. I was able to initialize the auth library on backend as required.

Without these changes I got the following error:
```
Error initializing auth library. Unable to import public key
```