### PR TITLE
[TIC-878] Resend email confirmation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.1.16",
             "license": "MIT",
             "dependencies": {
-                "@propelauth/node-apis": "file:.yalc/@propelauth/node-apis",
+                "@propelauth/node-apis": "^2.1.14",
                 "jose": "^5.2.0"
             },
             "devDependencies": {
@@ -31,10 +31,6 @@
                 "typescript": "^4.2.4",
                 "uuid": "^8.3.2"
             }
-        },
-        ".yalc/@propelauth/node-apis": {
-            "version": "2.1.13",
-            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.23.5",
@@ -1052,8 +1048,9 @@
             }
         },
         "node_modules/@propelauth/node-apis": {
-            "resolved": ".yalc/@propelauth/node-apis",
-            "link": true
+            "version": "2.1.14",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.14.tgz",
+            "integrity": "sha512-B7KkXDb0oSLi3c4GRoTclvP6OHg+pfHFc/J1Wl2hXigRh7G+862xOV3/FjgHLHtlcseh8nK10O5Nj7997Z38WQ=="
         },
         "node_modules/@rollup/plugin-commonjs": {
             "version": "19.0.2",
@@ -5522,7 +5519,9 @@
             }
         },
         "@propelauth/node-apis": {
-            "version": "file:.yalc/@propelauth/node-apis"
+            "version": "2.1.14",
+            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.14.tgz",
+            "integrity": "sha512-B7KkXDb0oSLi3c4GRoTclvP6OHg+pfHFc/J1Wl2hXigRh7G+862xOV3/FjgHLHtlcseh8nK10O5Nj7997Z38WQ=="
         },
         "@rollup/plugin-commonjs": {
             "version": "19.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@propelauth/node",
-    "version": "2.1.14",
+    "version": "2.1.16",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@propelauth/node",
-            "version": "2.1.14",
+            "version": "2.1.16",
             "license": "MIT",
             "dependencies": {
-                "@propelauth/node-apis": "^2.1.13",
+                "@propelauth/node-apis": "file:.yalc/@propelauth/node-apis",
                 "jose": "^5.2.0"
             },
             "devDependencies": {
@@ -34,7 +34,6 @@
         },
         ".yalc/@propelauth/node-apis": {
             "version": "2.1.13",
-            "extraneous": true,
             "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
@@ -1053,9 +1052,8 @@
             }
         },
         "node_modules/@propelauth/node-apis": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.13.tgz",
-            "integrity": "sha512-QUeSWlVocV5WHc+ymqYcnYqO+6NJ5xFzVhU9OE2mQ9gdt4xTsKr6eVL4GxmCnyVEOVn7c6Q8ijZOsyBZz85e2w=="
+            "resolved": ".yalc/@propelauth/node-apis",
+            "link": true
         },
         "node_modules/@rollup/plugin-commonjs": {
             "version": "19.0.2",
@@ -5524,9 +5522,7 @@
             }
         },
         "@propelauth/node-apis": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/@propelauth/node-apis/-/node-apis-2.1.13.tgz",
-            "integrity": "sha512-QUeSWlVocV5WHc+ymqYcnYqO+6NJ5xFzVhU9OE2mQ9gdt4xTsKr6eVL4GxmCnyVEOVn7c6Q8ijZOsyBZz85e2w=="
+            "version": "file:.yalc/@propelauth/node-apis"
         },
         "@rollup/plugin-commonjs": {
             "version": "19.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.13",
+        "@propelauth/node-apis": "file:.yalc/@propelauth/node-apis",
         "jose": "^5.2.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node-apis": "file:.yalc/@propelauth/node-apis",
+        "@propelauth/node-apis": "^2.1.14",
         "jose": "^5.2.0"
     },
     "devDependencies": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -105,6 +105,7 @@ export function initBaseAuth(opts: BaseAuthOptions) {
         disableUser: apis.disableUser,
         enableUser: apis.enableUser,
         disableUser2fa: apis.disableUser2fa,
+        resendEmailConfirmation: apis.resendEmailConfirmation,
         enableUserCanCreateOrgs: apis.enableUserCanCreateOrgs,
         disableUserCanCreateOrgs: apis.disableUserCanCreateOrgs,
         // org management functions


### PR DESCRIPTION
# Background

A new request has been added -- `resendEmailConfirmation`. This will allow a user to resend an email confirmation for a created, unconfirmed user. 

## Usage
Here is a basic example usage of this request:
```ts
const {
  resendEmailConfirmation,
} = propelAuth.initBaseAuth({
  authUrl: AUTH_URL,
  apiKey: API_KEY,
});

resendEmailConfirmation("<User ID>").then((res) => {
	if (res) {
		console.log("Resent successfully");
	} else {
		console.log("Error resending");
	}
}).catch(...);
```