### PR TITLE
feat(npm): add worker support for node package

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -43,11 +43,24 @@
         "test": "jest --silent",
         "prepublishOnly": "npm run build"
     },
-    "main": "dist/index.js",
-    "module": "dist/index.es.js",
+    "main": "dist/node/cjs/index.js",
+    "module": "dist/node/esm/index.js",
     "files": [
         "dist"
     ],
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "bun": "./dist/browser/index.js",
+            "deno": "./dist/browser/index.js",
+            "browser": "./dist/browser/index.js",
+            "worker": "./dist/browser/index.js",
+            "workerd": "./dist/browser/index.js",
+            "import": "./dist/node/esm/index.js",
+            "require": "./dist/node/cjs/index.js"
+        },
+        "./package.json": "./package.json"
+    },
     "jest": {
         "testMatch": [
             "**/test/*.ts"

--- a/packages/node/rollup.config.js
+++ b/packages/node/rollup.config.js
@@ -11,8 +11,7 @@ const globals = {
     ...packageJson.devDependencies,
 }
 
-export default {
-    input: "src/index.ts",
+export default [{
     output: [
         {
             file: packageJson.main,
@@ -23,15 +22,31 @@ export default {
             file: packageJson.module,
             format: "esm",
             sourcemap: true,
-        },
+        }
     ],
+    resolveConfig: {
+        extensions,
+    },
+}, {
+    output: {
+        exports: "named",
+        format: "es",
+        file: "dist/browser/index.js",
+        sourcemap: true,
+    },
+    resolveConfig: {
+        extensions,
+        exportConditions: ["browser", "worker"],
+        browser: true,
+    },
+}].map(config => ({
+    input: "src/index.ts",
+    output: config.output,
     plugins: [
         peerDepsExternal(),
-        resolve({
-            extensions,
-        }),
+        resolve(config.resolveConfig),
         commonjs(),
         typescript(),
     ],
     external: Object.keys(globals),
-}
+}))


### PR DESCRIPTION
This PR adds a 3rd output type for browsers/workers. This is needed so that `@propelauth/cloudflare-worker` can import it correctly (using the `jose` browser runtime instead of node runtime). This fixes #48.