### PR TITLE
bump node-apis version to 2.1.26 and re-export types

### DIFF
--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -57,7 +57,7 @@
         }
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.24",
+        "@propelauth/node-apis": "^2.1.26",
         "jose": "^5.2.0"
     }
 }

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -41,6 +41,9 @@ export {
     UpdateUserEmailException,
     UpdateUserMetadataException,
     RevokePendingOrgInviteRequest,
+    FetchSamlSpMetadataResponse,
+    SetSamlIdpMetadataRequest,
+    IdpProvider,
 } from "@propelauth/node-apis"
 export {
     User,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.24",
+        "@propelauth/node-apis": "^2.1.26",
         "jose": "^5.2.0"
     },
     "devDependencies": {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -78,6 +78,9 @@ export type {
     PendingInvitesPage,
     PendingInvite,
     RevokePendingOrgInviteRequest,
+    FetchSamlSpMetadataResponse,
+    SetSamlIdpMetadataRequest,
+    IdpProvider,
 } from "@propelauth/node-apis"
 export {
     BaseAuthOptions,


### PR DESCRIPTION
depends on [this node-apis PR](https://github.com/PropelAuth/node-apis/pull/26) merging and a patch version bump there