### PR TITLE
pass through RateLimitedException, bump to 2.1.29

### DIFF
--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/cloudflare-worker"
     },
-    "version": "2.1.28",
+    "version": "2.1.29",
     "license": "MIT",
     "keywords": [
         "auth",
@@ -57,7 +57,7 @@
         }
     },
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.28",
+        "@propelauth/node-apis": "^2.1.29",
         "jose": "^5.2.0"
     }
 }

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -41,6 +41,7 @@ export {
     UnauthorizedException,
     UpdateUserEmailException,
     UpdateUserMetadataException,
+    RateLimitedException,
     RevokePendingOrgInviteRequest,
     FetchSamlSpMetadataResponse,
     SetSamlIdpMetadataRequest,

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/PropelAuth/node"
     },
-    "version": "2.1.28",
+    "version": "2.1.29",
     "license": "MIT",
     "keywords": [
         "auth",
@@ -12,7 +12,7 @@
         "user"
     ],
     "dependencies": {
-        "@propelauth/node-apis": "^2.1.28",
+        "@propelauth/node-apis": "^2.1.29",
         "jose": "^5.2.0"
     },
     "devDependencies": {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -16,6 +16,7 @@ export {
     MagicLinkCreationException,
     MigrateUserException,
     OrgMemberInfo,
+    RateLimitedException,
     RemoveUserFromOrgException,
     toOrgIdToOrgMemberInfo,
     toUser,


### PR DESCRIPTION
Depends on [upstream PR](https://github.com/PropelAuth/node-apis/pull/31) and will fail CI until that's merged.

## Tests
Included in tests described in detail on above PR.